### PR TITLE
fix custom enum export error

### DIFF
--- a/Source/UnrealCSharpCore/Private/FUnrealCSharpFunctionLibrary.cpp
+++ b/Source/UnrealCSharpCore/Private/FUnrealCSharpFunctionLibrary.cpp
@@ -112,6 +112,10 @@ FString FUnrealCSharpFunctionLibrary::GetClassNameSpace(const UEnum* InStruct)
 	{
 		ModuleName = ModuleName.Replace(TEXT("/Script/"), TEXT("/"));
 	}
+	else
+	{
+		ModuleName = ModuleName.Replace(*("/" + InStruct->GetName()), TEXT(""));
+	}
 
 	return FString::Printf(TEXT(
 		"%s%s"


### PR DESCRIPTION
自定义 Enum 导出时 命名空间导致报错
```cs
namespace Script.Game.BP.TargetType
{
	[PathName("/Game/BP/TargetType.TargetType")]
	public enum TargetType : Int64
	{
		New_h20_Enumerator_h20_5 = 0,
	}
}
```
修正为
```cs
namespace Script.Game.BP
{
	[PathName("/Game/BP/TargetType.TargetType")]
	public enum TargetType : Int64
	{
		New_h20_Enumerator_h20_5 = 0,
	}
}
```