### PR TITLE
fixed Blueprint Export Miss

### DIFF
--- a/Source/Generator/Private/FBlueprintGenerator.cpp
+++ b/Source/Generator/Private/FBlueprintGenerator.cpp
@@ -32,8 +32,9 @@ void FBlueprintGenerator::Generator()
 
 	for (const auto& AssetData : OutAssetData)
 	{
-		if (AssetData.AssetClass == UBlueprint::StaticClass()->GetFName() ||
-			AssetData.AssetClass == UWidgetBlueprint::StaticClass()->GetFName())
+		auto AssetName = AssetData.AssetClass != "None" ? AssetData.AssetClass : AssetData.GetClass()->GetFName();
+		if (AssetName == UBlueprint::StaticClass()->GetFName() ||
+			AssetName == UWidgetBlueprint::StaticClass()->GetFName())
 		{
 			if (const auto Blueprint = LoadObject<
 				UBlueprint>(nullptr, *AssetData.ObjectPath.ToString()))
@@ -44,7 +45,7 @@ void FBlueprintGenerator::Generator()
 				}
 			}
 		}
-		else if (AssetData.AssetClass == UUserDefinedStruct::StaticClass()->GetFName())
+		else if (AssetName == UUserDefinedStruct::StaticClass()->GetFName())
 		{
 			if (const auto UserDefinedStruct = LoadObject<
 				UUserDefinedStruct>(nullptr, *AssetData.ObjectPath.ToString()))
@@ -52,7 +53,7 @@ void FBlueprintGenerator::Generator()
 				FStructGenerator::Generator(UserDefinedStruct);
 			}
 		}
-		else if (AssetData.AssetClass == UUserDefinedEnum::StaticClass()->GetFName())
+		else if (AssetName == UUserDefinedEnum::StaticClass()->GetFName())
 		{
 			if (const auto UserDefinedEnum = LoadObject<
 				UUserDefinedEnum>(nullptr, *AssetData.ObjectPath.ToString()))


### PR DESCRIPTION
蓝图导出丢失, 原因是 导出判断的 AssetData.AssetClass字段为None 导致判断分支不通过 而未导出.
修复为 使用 GetClass()->GetFName() 获取类名