### PR TITLE
add generic method of GetDataTableRowFromName

### DIFF
--- a/Script/UE/Library/UDataTableFunctionLibraryImplementation.cs
+++ b/Script/UE/Library/UDataTableFunctionLibraryImplementation.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Runtime.CompilerServices;
+using Script.Common;
+using Script.Engine;
+using Script.Library;
+
+namespace Script.Library
+{
+    public static class UDataTableFunctionLibraryImplementation
+    {
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        public static extern Boolean UDataTableFunctionLibrary_GetDataTableRowFromNameImplementation<T>(UDataTable Table, string RowName, out T OutRow);
+    }
+}
+
+namespace Script.Engine
+{
+    public partial class UDataTableFunctionLibrary : UBlueprintFunctionLibrary
+    {
+        public static Boolean GetDataTableRowFromName<T>(UDataTable Table, FName RowName, out T OutRow)
+        {
+            return UDataTableFunctionLibraryImplementation
+                .UDataTableFunctionLibrary_GetDataTableRowFromNameImplementation(Table, RowName.ToString(), out OutRow);
+        }
+    }
+}

--- a/Source/UnrealCSharp/Private/Domain/InternalCall/UDataTableFunctionLibrary.cpp
+++ b/Source/UnrealCSharp/Private/Domain/InternalCall/UDataTableFunctionLibrary.cpp
@@ -1,0 +1,49 @@
+﻿#include "Domain/InternalCall/UDataTableFunctionLibrary.h"
+#include "Binding/Class/FBindingClassBuilder.h"
+#include "Bridge/FTypeBridge.h"
+#include "Environment/FCSharpEnvironment.h"
+#include "Macro/NamespaceMacro.h"
+
+struct UDataTableRegistry
+{
+	UDataTableRegistry()
+	{
+		FBindingClassBuilder(TEXT("UDataTableFunctionLibrary"), NAMESPACE_LIBRARY)
+			.Function("GetDataTableRowFromName",
+					  static_cast<void*>(
+						  UDataTableFunctionLibraryImplementation::UDataTableFunctionLibrary_GetDataTableRowFromNameImplementation))
+			.Register();
+	}
+};
+
+static UDataTableRegistry UDataTableRegistry;
+
+
+bool UDataTableFunctionLibraryImplementation::UDataTableFunctionLibrary_GetDataTableRowFromNameImplementation(
+	MonoObject* InTable,
+	MonoString* InRowName,
+	MonoObject** OutRow)
+{
+	const FName RowName = UTF8_TO_TCHAR(FCSharpEnvironment::GetEnvironment()->GetDomain()->String_To_UTF8(InRowName));
+
+	const UDataTable* DataTable = FCSharpEnvironment::GetEnvironment()->GetObject<UDataTable>(InTable);
+
+	const bool IsBind = FCSharpEnvironment::GetEnvironment()->Bind(DataTable->RowStruct.Get(), false);
+
+	const auto StructDescriptor = FCSharpEnvironment::GetEnvironment()->GetClassDescriptor(DataTable->RowStruct.Get());
+	
+	if (!IsBind || StructDescriptor == nullptr)
+	{
+		return false;
+	}
+	
+	*OutRow = FCSharpEnvironment::GetEnvironment()->GetDomain()->Object_New(StructDescriptor->GetMonoClass());
+
+	const auto FindRowData = *DataTable->GetRowMap().Find(RowName);
+
+	const auto OutRowData = FCSharpEnvironment::GetEnvironment()->GetStruct(*OutRow);
+
+	DataTable->RowStruct->CopyScriptStruct(OutRowData, FindRowData);
+
+	return true;
+}

--- a/Source/UnrealCSharp/Public/Domain/InternalCall/UDataTableFunctionLibrary.h
+++ b/Source/UnrealCSharp/Public/Domain/InternalCall/UDataTableFunctionLibrary.h
@@ -1,0 +1,8 @@
+﻿#pragma once
+#include "mono/metadata/object.h"
+
+class UDataTableFunctionLibraryImplementation
+{
+public:
+	static bool UDataTableFunctionLibrary_GetDataTableRowFromNameImplementation(MonoObject* InTable, MonoString* InRowName, MonoObject** OutRow);
+};


### PR DESCRIPTION
静态导出了 操作UDataTable 的泛型GetDataTableRowFromName 方法, 用于根据行名RowName从DataTable中查找行数据RowData,并转为T结构体