### PR TITLE
代码分析工具的bug和TArray/TSet的泛型迭代器支持

### DIFF
--- a/Script/CodeAnalysis/CodeAnalysis.cs
+++ b/Script/CodeAnalysis/CodeAnalysis.cs
@@ -57,7 +57,7 @@ namespace CodeAnalysis
 
             var Root = (CompilationUnitSyntax) Tree.GetRoot();
 
-            foreach (NamespaceDeclarationSyntax NamespaceDeclaration in Root.Members)
+            foreach (BaseNamespaceDeclarationSyntax NamespaceDeclaration in Root.Members)
             {
                 foreach (ClassDeclarationSyntax ClassDeclaration in NamespaceDeclaration.Members)
                 {

--- a/Script/CodeAnalysis/CodeAnalysis.cs
+++ b/Script/CodeAnalysis/CodeAnalysis.cs
@@ -57,31 +57,19 @@ namespace CodeAnalysis
 
             var Root = (CompilationUnitSyntax) Tree.GetRoot();
 
-            foreach (BaseNamespaceDeclarationSyntax NamespaceDeclaration in Root.Members)
+            foreach (var RootMember in Root.Members)
             {
-                foreach (ClassDeclarationSyntax ClassDeclaration in NamespaceDeclaration.Members)
+                if (RootMember is BaseNamespaceDeclarationSyntax NamespaceDeclaration)
                 {
-                    var Functions = new List<string>();
-
-                    var bIsOverride = false;
-
-                    foreach (var Attribute in ClassDeclaration.AttributeLists)
+                    foreach (var NameSpaceMember in NamespaceDeclaration.Members)
                     {
-                        if (Attribute.ToString().Equals("[IsOverride]"))
+                        if (NameSpaceMember is ClassDeclarationSyntax ClassDeclaration)
                         {
-                            bIsOverride = true;
+                            var Functions = new List<string>();
 
-                            break;
-                        }
-                    }
+                            var bIsOverride = false;
 
-                    if (bIsOverride)
-                    {
-                        foreach (MethodDeclarationSyntax MethodDeclaration in ClassDeclaration.Members)
-                        {
-                            bIsOverride = false;
-
-                            foreach (var Attribute in MethodDeclaration.AttributeLists)
+                            foreach (var Attribute in ClassDeclaration.AttributeLists)
                             {
                                 if (Attribute.ToString().Equals("[IsOverride]"))
                                 {
@@ -93,21 +81,43 @@ namespace CodeAnalysis
 
                             if (bIsOverride)
                             {
-                                Functions.Add(MethodDeclaration.Identifier.ToString());
+                                foreach (var MemberDeclaration in ClassDeclaration.Members)
+                                {
+                                    if (MemberDeclaration is MethodDeclarationSyntax MethodDeclaration)
+                                    {
+                                        bIsOverride = false;
+
+                                        foreach (var Attribute in MethodDeclaration.AttributeLists)
+                                        {
+                                            if (Attribute.ToString().Equals("[IsOverride]"))
+                                            {
+                                                bIsOverride = true;
+
+                                                break;
+                                            }
+                                        }
+
+                                        if (bIsOverride)
+                                        {
+                                            Functions.Add(MethodDeclaration.Identifier.ToString());
+                                        }
+                                    }
+                                }
+                            }
+
+                            if (Functions.Count > 0)
+                            {
+                                var FileName = Path.Combine(InPathName,
+                                    String.Format("{0}.{1}.json", NamespaceDeclaration.Name, ClassDeclaration.Identifier));
+
+                                var Value = String.Format("{{\"Override\":{0}}}", JsonSerializer.Serialize(Functions));
+
+                                File.WriteAllText(FileName, Value);
                             }
                         }
                     }
-
-                    if (Functions.Count > 0)
-                    {
-                        var FileName = Path.Combine(InPathName,
-                            String.Format("{0}.{1}.json", NamespaceDeclaration.Name, ClassDeclaration.Identifier));
-
-                        var Value = String.Format("{{\"Override\":{0}}}", JsonSerializer.Serialize(Functions));
-
-                        File.WriteAllText(FileName, Value);
-                    }
                 }
+               
             }
         }
     }

--- a/Script/UE/Common/Array.cs
+++ b/Script/UE/Common/Array.cs
@@ -1,10 +1,11 @@
 ﻿using System;
 using System.Collections;
+using System.Collections.Generic;
 using Script.Reflection.Container;
 
 namespace Script.Common
 {
-    public class TArray<T> : IEnumerable
+    public class TArray<T> : IEnumerable<T>
     {
         public TArray() => ArrayUtils.Array_Register(this);
 
@@ -12,15 +13,23 @@ namespace Script.Common
         {
         }
 
-        ~TArray() => ArrayUtils.Array_UnRegister(this);
-
-        public IEnumerator GetEnumerator()
+        public IEnumerator<T> GetEnumerator()
         {
             for (var Index = 0; Index < Num(); Index++)
             {
                 yield return this[Index];
             }
         }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            for (var Index = 0; Index < Num(); Index++)
+            {
+                yield return this[Index];
+            }
+        }
+        ~TArray() => ArrayUtils.Array_UnRegister(this);
+
 
         public Int32 GetTypeSize() => ArrayUtils.Array_GetTypeSize(this);
 
@@ -78,5 +87,7 @@ namespace Script.Common
 
         public void Swap(Int32 InFirstIndexToSwap, Int32 InSecondIndexToSwap) =>
             ArrayUtils.Array_Swap(this, InFirstIndexToSwap, InSecondIndexToSwap);
+
+
     }
 }

--- a/Script/UE/Common/Set.cs
+++ b/Script/UE/Common/Set.cs
@@ -1,10 +1,11 @@
 ﻿using System;
 using Script.Reflection.Container;
 using System.Collections;
+using System.Collections.Generic;
 
 namespace Script.Common
 {
-    public class TSet<T> : IEnumerable
+    public class TSet<T> : IEnumerable<T>
     {
         public TSet() => SetUtils.Set_Register(this);
 
@@ -12,7 +13,18 @@ namespace Script.Common
         {
         }
 
-        public IEnumerator GetEnumerator()
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            for (var Index = 0; Index < Num(); Index++)
+            {
+                if (IsValidIndex(Index))
+                {
+                    yield return this[Index];
+                }
+            }
+        }
+        IEnumerator IEnumerable.GetEnumerator()
         {
             for (var Index = 0; Index < Num(); Index++)
             {
@@ -38,6 +50,7 @@ namespace Script.Common
         public Boolean Contains(T InValue) => SetUtils.Set_Contains(this, InValue);
 
         private Boolean IsValidIndex(Int32 InIndex) => SetUtils.Set_IsValidIndex(this, InIndex);
+
 
         private T this[Int32 InIndex] => SetUtils.Set_GetEnumerator(this, InIndex);
     }


### PR DESCRIPTION
1. 代码分析工具直接转换member的类型，很容易因为member不是预期类型而crash，for循环中加了if判断
2. TArray/TSet没有支持泛型迭代器，加上了