### PR TITLE
修复关闭UE时的崩溃

### DIFF
--- a/Source/Compiler/Private/FCSharpCompiler.cpp
+++ b/Source/Compiler/Private/FCSharpCompiler.cpp
@@ -6,15 +6,19 @@ FCSharpCompiler::FCSharpCompiler():
 {
 	Runnable = new FCSharpCompilerRunnable();
 
-	FRunnableThread::Create(Runnable, TEXT("CSharpCompiler"));
+	Thread = FRunnableThread::Create(Runnable, TEXT("CSharpCompiler"));
 }
 
 FCSharpCompiler::~FCSharpCompiler()
 {
-	if (Runnable != nullptr)
+	if (Thread != nullptr)
 	{
-		delete Runnable;
+		Thread->Kill(true);
 
+		delete Thread;
+		Thread = nullptr;
+
+		delete Runnable;
 		Runnable = nullptr;
 	}
 }

--- a/Source/Compiler/Private/FCSharpCompilerRunnable.cpp
+++ b/Source/Compiler/Private/FCSharpCompilerRunnable.cpp
@@ -16,7 +16,8 @@
 FCSharpCompilerRunnable::FCSharpCompilerRunnable():
 	Event(nullptr),
 	bIsCompiling(false),
-	bIsGenerating(false)
+	bIsGenerating(false),
+	bIsStop(false)
 {
 	OnBeginGeneratorDelegateHandle = FUnrealCSharpCoreModuleDelegates::OnBeginGenerator.AddRaw(
 		this, &FCSharpCompilerRunnable::OnBeginGenerator);
@@ -49,6 +50,10 @@ uint32 FCSharpCompilerRunnable::Run()
 {
 	while (true)
 	{
+		if (bIsStop)
+		{
+			return 0;
+		}
 		if (!bIsGenerating)
 		{
 			if (!Tasks.IsEmpty())
@@ -82,8 +87,12 @@ uint32 FCSharpCompilerRunnable::Run()
 
 void FCSharpCompilerRunnable::Stop()
 {
+	bIsStop = true;
+	
 	if (Event != nullptr)
 	{
+		Event->Trigger();
+
 		FPlatformProcess::ReturnSynchEventToPool(Event);
 
 		Event = nullptr;

--- a/Source/Compiler/Public/FCSharpCompiler.h
+++ b/Source/Compiler/Public/FCSharpCompiler.h
@@ -25,4 +25,5 @@ public:
 
 private:
 	class FCSharpCompilerRunnable* Runnable;
+	FRunnableThread* Thread;
 };

--- a/Source/Compiler/Public/FCSharpCompilerRunnable.h
+++ b/Source/Compiler/Public/FCSharpCompilerRunnable.h
@@ -55,4 +55,6 @@ private:
 	bool bIsCompiling;
 
 	bool bIsGenerating;
+
+	bool bIsStop;
 };


### PR DESCRIPTION
<details><summary>崩溃日志</summary>

```
2024-06-22 13:57:34.362 UnrealEditor[72618:6608503] [UE] [2024.06.22-05.57.34:362][245]LogExit: Exiting.

=================================================================
        Native Crash Reporting
=================================================================
Got a SIGSEGV while executing native code. This usually indicates
a fatal error in the mono runtime or one of the native libraries 
used by your application.
=================================================================

=================================================================
        Native stacktrace:
=================================================================
        0x49b9eba7c - /Volumes/Resource2/VMShare/StoryGame/Plugins/UnrealCSharp/Binaries/Mac/UnrealEditor-UnrealCSharpCore.dylib : mono_dump_native_crash_info
        0x49b99f688 - /Volumes/Resource2/VMShare/StoryGame/Plugins/UnrealCSharp/Binaries/Mac/UnrealEditor-UnrealCSharpCore.dylib : mono_handle_native_crash
        0x49b91031c - /Volumes/Resource2/VMShare/StoryGame/Plugins/UnrealCSharp/Binaries/Mac/UnrealEditor-UnrealCSharpCore.dylib : mono_sigsegv_signal_handler_debug
        0x19ab6f584 - /usr/lib/system/libsystem_platform.dylib : _sigtramp
        0x49347a73c - /Volumes/Resource2/VMShare/StoryGame/Plugins/UnrealCSharp/Binaries/Mac/UnrealEditor-Compiler.dylib : _ZN23FCSharpCompilerRunnable3RunEv
        0x1025aade0 - /Volumes/Resource2/VMShare/EngineBuild/Engine/Binaries/Mac/UnrealEditor-Core.dylib : _ZN22FRunnableThreadPThread3RunEv
        0x1024fce40 - /Volumes/Resource2/VMShare/EngineBuild/Engine/Binaries/Mac/UnrealEditor-Core.dylib : _ZN22FRunnableThreadPThread11_ThreadProcEPv
        0x19ab3ef94 - /usr/lib/system/libsystem_pthread.dylib : _pthread_start
        0x19ab39d34 - /usr/lib/system/libsystem_pthread.dylib : thread_start

=================================================================
        External Debugger Dump:
=================================================================

=================================================================
        Basic Fault Address Reporting
=================================================================
Memory around native instruction pointer (0x49347a6c0):0x49347a6b0  02 00 00 14 68 26 42 39 e8 ff ff 35 68 16 40 f9  ....h&B9...5h.@.
0x49347a6c0  08 01 40 f9 e8 02 00 b4 34 01 00 b5 c0 82 04 70  ..@.....4......p
0x49347a6d0  1f 20 03 d5 e1 03 16 aa c2 04 80 52 e3 03 17 aa  . .........R....
0x49347a6e0  11 1b 00 94 40 00 00 34 00 00 3e d4 e0 03 14 aa  ....@..4..>.....
```



</details> 

因为FCSharpCompiler没有让Runnable退出导致Runnable线程访问了析构后的Tasks然后空指针崩溃