### PR TITLE
导出FCSharpBind和FClassRegistry

### DIFF
--- a/Source/UnrealCSharp/Public/Registry/FCSharpBind.h
+++ b/Source/UnrealCSharp/Public/Registry/FCSharpBind.h
@@ -3,7 +3,7 @@
 #include "Domain/FDomain.h"
 #include "Reflection/Class/FClassDescriptor.h"
 
-class FCSharpBind
+class UNREALCSHARP_API FCSharpBind
 {
 public:
 	FCSharpBind();

--- a/Source/UnrealCSharp/Public/Registry/FClassRegistry.h
+++ b/Source/UnrealCSharp/Public/Registry/FClassRegistry.h
@@ -2,7 +2,7 @@
 
 #include "Reflection/Class/FClassDescriptor.h"
 
-class FClassRegistry
+class UNREALCSHARP_API FClassRegistry
 {
 public:
 	FClassRegistry();


### PR DESCRIPTION
导出FCSharpBind和FClassRegistry可以让用户在插件外部静态导出时使用FCSharpBind::Bind或者 FCSharpEnvironment::GetClassDescriptor返回UObject