### PR TITLE
打印完C#堆栈后恢复默认的Signal处理逻辑

### DIFF
--- a/Source/UnrealCSharp/Private/Environment/FCSharpEnvironment.cpp
+++ b/Source/UnrealCSharp/Private/Environment/FCSharpEnvironment.cpp
@@ -114,7 +114,14 @@ void FCSharpEnvironment::Initialize()
 		FMemory::Memzero(&Action, sizeof(struct sigaction));
 		Action.sa_handler = SignalHandler;
 		sigemptyset(&Action.sa_mask);
-		sigaction(SignalType, &Action, &SignalDefaultAction.FindOrAdd(SignalType));
+		if (!SignalDefaultAction.Contains(SignalType))
+		{
+			sigaction(SignalType, &Action, &SignalDefaultAction.Add(SignalType));
+		}
+		else
+		{
+			sigaction(SignalType, &Action, nullptr);
+		}
 #endif
 	}
 

--- a/Source/UnrealCSharp/Private/Environment/FCSharpEnvironment.cpp
+++ b/Source/UnrealCSharp/Private/Environment/FCSharpEnvironment.cpp
@@ -19,9 +19,11 @@ void SignalHandler(int32 Signal)
 		       FCSharpEnvironment::GetEnvironment().GetDomain()->GetTraceback()))));
 
 	GLog->Flush();
+
 #if PLATFORM_MAC
 	sigaction(Signal, &SignalDefaultAction[Signal], nullptr);
 #endif
+
 }
 
 FCSharpEnvironment FCSharpEnvironment::Environment;

--- a/Source/UnrealCSharp/Private/Environment/FCSharpEnvironment.cpp
+++ b/Source/UnrealCSharp/Private/Environment/FCSharpEnvironment.cpp
@@ -8,7 +8,7 @@
 #include "Log/UnrealCSharpLog.h"
 #include <signal.h>
 
-#if !PLATFORM_WINDOWS
+#if PLATFORM_MAC
 TMap<int32, struct sigaction> SignalDefaultAction;
 #endif
 
@@ -19,9 +19,7 @@ void SignalHandler(int32 Signal)
 		       FCSharpEnvironment::GetEnvironment().GetDomain()->GetTraceback()))));
 
 	GLog->Flush();
-#if PLATFORM_WINDOWS
-	signal(Signal,SIG_DFL);
-#else
+#if PLATFORM_MAC
 	sigaction(Signal, &SignalDefaultAction[Signal], nullptr);
 #endif
 }
@@ -107,9 +105,7 @@ void FCSharpEnvironment::Initialize()
 
 	for (const auto SignalType : SignalTypes)
 	{
-#if PLATFORM_WINDOWS
-		signal(SignalType, SignalHandler);
-#else
+#if PLATFORM_MAC
 		struct sigaction Action;
 		FMemory::Memzero(&Action, sizeof(struct sigaction));
 		Action.sa_handler = SignalHandler;
@@ -122,6 +118,8 @@ void FCSharpEnvironment::Initialize()
 		{
 			sigaction(SignalType, &Action, nullptr);
 		}
+#else
+		signal(SignalType, SignalHandler);
 #endif
 	}
 


### PR DESCRIPTION
在SignalHandler的C#堆栈打印完成后恢复默认的处理程序，这可以让引擎能处理这些Signal（比如打印崩溃堆栈，调起Crash Reporter）。如果不恢复默认处理程序当发生SIGSEGV这类C++异常时会一直卡在这里输出C#堆栈需要手动结束进程