### PR TITLE
修复启动Mac打包产物时崩溃的问题

### DIFF
--- a/Source/UnrealCSharpCore/Private/Domain/AssemblyLoader.cpp
+++ b/Source/UnrealCSharpCore/Private/Domain/AssemblyLoader.cpp
@@ -43,7 +43,7 @@ TArray<uint8> UAssemblyLoader::Load(const FString& InAssemblyName)
 	                                  MONO_CONFIGURATION,
 	                                  TEXT("macOS_x86_64"));
 #elif PLATFORM_MAC_ARM64
-	                                  TEXT("macOS_arm64"),
+	                                  TEXT("Mac"),
 	                                  MONO_CONFIGURATION,
 	                                  TEXT("macOS_arm64"));
 #endif


### PR DESCRIPTION
理论上x86 Mac也有一样的问题，但我手上没有x86的Mac能过进行测试就先只改Arm架构的