### PR TITLE
Params export key fix and eport system enum value by displayname

### DIFF
--- a/Source/ScriptCodeGenerator/Private/FClassGenerator.cpp
+++ b/Source/ScriptCodeGenerator/Private/FClassGenerator.cpp
@@ -487,21 +487,10 @@ void FClassGenerator::Generator(const UClass* InClass)
 			if (FunctionParams[Index]->HasAnyPropertyFlags(CPF_OutParm) && !FunctionParams[Index]->HasAnyPropertyFlags(
 				CPF_ConstParm))
 			{
-				if (FUnrealCSharpFunctionLibrary::IsNativeFunction(InClass, Function->GetFName()) ||
-					FunctionParams[Index]->HasAnyPropertyFlags(CPF_ReferenceParm))
-				{
-					FunctionOutParamIndexMapping[FunctionParams.Num() - 1 - FunctionRefParamIndex.Num()] =
-						FunctionRefParamIndex.Num() + FunctionOutParamIndex.Num();
+				FunctionOutParamIndexMapping[FunctionParams.Num() - 1 - FunctionRefParamIndex.Num()] =
+					FunctionRefParamIndex.Num() + FunctionOutParamIndex.Num();
 
-					FunctionRefParamIndex.Emplace(Index);
-				}
-				else
-				{
-					FunctionOutParamIndexMapping[FunctionOutParamIndex.Num()] =
-						FunctionRefParamIndex.Num() + FunctionOutParamIndex.Num();
-
-					FunctionOutParamIndex.Emplace(Index);
-				}
+				FunctionRefParamIndex.Emplace(Index);
 			}
 
 			if (bGeneratorFunctionDefaultParam == false)

--- a/Source/ScriptCodeGenerator/Private/FClassGenerator.cpp
+++ b/Source/ScriptCodeGenerator/Private/FClassGenerator.cpp
@@ -1074,18 +1074,21 @@ FString FClassGenerator::GetBlueprintFunctionDefaultParam(const UFunction* InFun
 	}
 
 	const auto Key = InProperty->GetName();
-
+	
 	const auto MetaData = InFunction->GetMetaData(*Key);
 
 	if (const auto ByteProperty = CastField<FByteProperty>(InProperty))
 	{
 		if (ByteProperty->Enum != nullptr)
 		{
-			if (const auto UserDefinedEnum = Cast<UUserDefinedEnum>(ByteProperty->Enum))
+			auto EnumValueIndex = ByteProperty->Enum->GetIndexByNameString(MetaData);
+			
+			FText DisplayName = ByteProperty->Enum->GetDisplayNameTextByValue(EnumValueIndex);
+
+			if (!DisplayName.IsEmpty())
 			{
 				return FString::Printf(TEXT(" = %s.%s"), *ByteProperty->Enum->GetName(),
-				                       *UserDefinedEnum->GetDisplayNameTextByIndex(
-					                       UserDefinedEnum->GetIndexByNameString(MetaData)).ToString());
+									   *DisplayName.ToString());
 			}
 			else
 			{


### PR DESCRIPTION
1.导出FunctionDefaultParam时，使用的displayname只包含了userdefined类型，然而system enum也有可能需要使用displayname导出，不然可能cs会找不到值（例子：使用ECollisionChannel）
2.发现CPF_OutParm && !CPF_ConstParm的导出时，无论C++还是蓝图函数，作为输出参数时，都只需要导出为ref关键字（可能还有需要out导出的需求，我没考虑到，可以提供 ）（这样导出的函数就能解决issue接口Native &问题，接口Native直接判断成本稍微高了些，不确定哪一层继承的接口，FunctionFind可能中间层中断）