### PR TITLE
Fix String_To_UTF8 memory leak issue

### DIFF
--- a/Source/UnrealCSharp/Private/Domain/FDomain.cpp
+++ b/Source/UnrealCSharp/Private/Domain/FDomain.cpp
@@ -352,6 +352,11 @@ char* FDomain::String_To_UTF8(MonoString* InMonoString) const
 	return FMonoDomain::String_To_UTF8(InMonoString);
 }
 
+FScopedMonoUTF8Char FDomain::String_To_Scoped_UTF8(MonoString* InMonoString) const
+{
+	return FMonoDomain::String_To_Scoped_UTF8(InMonoString);
+}
+
 MonoArray* FDomain::Array_New(MonoClass* InMonoClass, const uint32 InNum) const
 {
 	return FMonoDomain::Array_New(InMonoClass, InNum);

--- a/Source/UnrealCSharp/Private/Domain/InternalCall/FRegisterAnsiString.cpp
+++ b/Source/UnrealCSharp/Private/Domain/InternalCall/FRegisterAnsiString.cpp
@@ -12,7 +12,7 @@ namespace
 		static void RegisterImplementation(MonoObject* InMonoObject, MonoString* InValue)
 		{
 			const auto AnsiString = new FAnsiString(UTF8_TO_TCHAR(
-				FCSharpEnvironment::GetEnvironment().GetDomain()->String_To_UTF8(InValue)));
+				FCSharpEnvironment::GetEnvironment().GetDomain()->String_To_Scoped_UTF8(InValue)));
 
 			FCSharpEnvironment::GetEnvironment().AddStringReference<FAnsiString, true, false>(InMonoObject, AnsiString);
 		}

--- a/Source/UnrealCSharp/Private/Domain/InternalCall/FRegisterName.cpp
+++ b/Source/UnrealCSharp/Private/Domain/InternalCall/FRegisterName.cpp
@@ -10,7 +10,7 @@ namespace
 		static void RegisterImplementation(MonoObject* InMonoObject, MonoString* InValue)
 		{
 			const auto Name = new FName(UTF8_TO_TCHAR(
-				FCSharpEnvironment::GetEnvironment().GetDomain()->String_To_UTF8(InValue)));
+				FCSharpEnvironment::GetEnvironment().GetDomain()->String_To_Scoped_UTF8(InValue)));
 
 			FCSharpEnvironment::GetEnvironment().AddStringReference<FName, true, false>(InMonoObject, Name);
 		}

--- a/Source/UnrealCSharp/Private/Domain/InternalCall/FRegisterObject.cpp
+++ b/Source/UnrealCSharp/Private/Domain/InternalCall/FRegisterObject.cpp
@@ -28,7 +28,7 @@ namespace
 		static MonoObject* StaticClassImplementation(MonoString* InClassName)
 		{
 			const auto ClassName =
-				UTF8_TO_TCHAR(FCSharpEnvironment::GetEnvironment().GetDomain()->String_To_UTF8(InClassName));
+				UTF8_TO_TCHAR(FCSharpEnvironment::GetEnvironment().GetDomain()->String_To_Scoped_UTF8(InClassName));
 
 			const auto InClass = LoadObject<UClass>(nullptr, ClassName);
 

--- a/Source/UnrealCSharp/Private/Domain/InternalCall/FRegisterString.cpp
+++ b/Source/UnrealCSharp/Private/Domain/InternalCall/FRegisterString.cpp
@@ -10,7 +10,7 @@ namespace
 		static void RegisterImplementation(MonoObject* InMonoObject, MonoString* InValue)
 		{
 			const auto String = new FString(UTF8_TO_TCHAR(
-				FCSharpEnvironment::GetEnvironment().GetDomain()->String_To_UTF8(InValue)));
+				FCSharpEnvironment::GetEnvironment().GetDomain()->String_To_Scoped_UTF8(InValue)));
 
 			FCSharpEnvironment::GetEnvironment().AddStringReference<FString, true, false>(InMonoObject, String);
 		}

--- a/Source/UnrealCSharp/Private/Domain/InternalCall/FRegisterStruct.cpp
+++ b/Source/UnrealCSharp/Private/Domain/InternalCall/FRegisterStruct.cpp
@@ -13,7 +13,7 @@ namespace
 		static MonoObject* StaticStructImplementation(MonoString* InStructName)
 		{
 			const auto StructName = UTF8_TO_TCHAR(
-				FCSharpEnvironment::GetEnvironment().GetDomain()->String_To_UTF8(InStructName));
+				FCSharpEnvironment::GetEnvironment().GetDomain()->String_To_Scoped_UTF8(InStructName));
 
 			const auto InStruct = LoadObject<UScriptStruct>(nullptr, StructName);
 
@@ -23,7 +23,7 @@ namespace
 		static void RegisterImplementation(MonoObject* InMonoObject, MonoString* InStructName)
 		{
 			const auto StructName = UTF8_TO_TCHAR(
-				FCSharpEnvironment::GetEnvironment().GetDomain()->String_To_UTF8(InStructName));
+				FCSharpEnvironment::GetEnvironment().GetDomain()->String_To_Scoped_UTF8(InStructName));
 
 			FCSharpEnvironment::GetEnvironment().Bind(InMonoObject, StructName);
 		}

--- a/Source/UnrealCSharp/Private/Domain/InternalCall/FRegisterText.cpp
+++ b/Source/UnrealCSharp/Private/Domain/InternalCall/FRegisterText.cpp
@@ -15,19 +15,19 @@ namespace
 		{
 			const auto Buffer = InBuffer != nullptr
 				                    ? UTF8_TO_TCHAR(
-					                    FCSharpEnvironment::GetEnvironment().GetDomain()->String_To_UTF8(
+					                    FCSharpEnvironment::GetEnvironment().GetDomain()->String_To_Scoped_UTF8(
 						                    InBuffer))
 				                    : nullptr;
 
 			const auto TextNamespace = InTextNamespace != nullptr
 				                           ? UTF8_TO_TCHAR(
-					                           FCSharpEnvironment::GetEnvironment().GetDomain()->String_To_UTF8(
+					                           FCSharpEnvironment::GetEnvironment().GetDomain()->String_To_Scoped_UTF8(
 						                           InTextNamespace))
 				                           : nullptr;
 
 			const auto PackageNamespace = InPackageNamespace != nullptr
 				                              ? UTF8_TO_TCHAR(
-					                              FCSharpEnvironment::GetEnvironment().GetDomain()->String_To_UTF8(
+					                              FCSharpEnvironment::GetEnvironment().GetDomain()->String_To_Scoped_UTF8(
 						                              InPackageNamespace))
 				                              : nullptr;
 

--- a/Source/UnrealCSharp/Private/Domain/InternalCall/FRegisterUtf8String.cpp
+++ b/Source/UnrealCSharp/Private/Domain/InternalCall/FRegisterUtf8String.cpp
@@ -12,7 +12,7 @@ namespace
 		static void RegisterImplementation(MonoObject* InMonoObject, MonoString* InValue)
 		{
 			const auto Utf8String = new FUtf8String(UTF8_TO_TCHAR(
-				FCSharpEnvironment::GetEnvironment().GetDomain()->String_To_UTF8(InValue)));
+				FCSharpEnvironment::GetEnvironment().GetDomain()->String_To_Scoped_UTF8(InValue)));
 
 			FCSharpEnvironment::GetEnvironment().AddStringReference<FUtf8String, true, false>(InMonoObject, Utf8String);
 		}

--- a/Source/UnrealCSharp/Private/Environment/FCSharpEnvironment.cpp
+++ b/Source/UnrealCSharp/Private/Environment/FCSharpEnvironment.cpp
@@ -19,7 +19,7 @@ TMap<int32, struct sigaction> SignalActions;
 void SignalHandler(int32 Signal)
 {
 	UE_LOG(LogUnrealCSharp, Error, TEXT("%s"),
-	       *FString(UTF8_TO_TCHAR(FCSharpEnvironment::GetEnvironment().GetDomain()->String_To_UTF8(
+	       *FString(UTF8_TO_TCHAR(FCSharpEnvironment::GetEnvironment().GetDomain()->String_To_Scoped_UTF8(
 		       FCSharpEnvironment::GetEnvironment().GetDomain()->GetTraceback()))));
 
 	GLog->Flush();

--- a/Source/UnrealCSharp/Public/Domain/FDomain.h
+++ b/Source/UnrealCSharp/Public/Domain/FDomain.h
@@ -147,6 +147,8 @@ public:
 	MonoString* Object_To_String(MonoObject* InMonoObject, MonoObject** InExc) const;
 
 	char* String_To_UTF8(MonoString* InMonoString) const;
+	
+	FScopedMonoUTF8Char String_To_Scoped_UTF8(MonoString* InMonoString) const;
 
 	MonoArray* Array_New(MonoClass* InMonoClass, uint32 InNum) const;
 

--- a/Source/UnrealCSharpCore/Private/Bridge/FTypeBridge.cpp
+++ b/Source/UnrealCSharpCore/Private/Bridge/FTypeBridge.cpp
@@ -876,7 +876,7 @@ FString FTypeBridge::GetPathName(MonoReflectionType* InReflectionType)
 	const auto PathNameMonoString = FMonoDomain::Object_To_String(
 		PathNameMonoObject, nullptr);
 
-	return UTF8_TO_TCHAR(FMonoDomain::String_To_UTF8(PathNameMonoString));
+	return UTF8_TO_TCHAR(FMonoDomain::String_To_Scoped_UTF8(PathNameMonoString));
 }
 
 FString FTypeBridge::GetGenericPathName(MonoReflectionType* InReflectionType)

--- a/Source/UnrealCSharpCore/Private/Domain/FMonoDomain.cpp
+++ b/Source/UnrealCSharpCore/Private/Domain/FMonoDomain.cpp
@@ -29,6 +29,22 @@
 
 PRAGMA_DISABLE_DANGLING_WARNINGS
 
+FScopedMonoUTF8Char::FScopedMonoUTF8Char(char* InPtr) : Ptr(InPtr)
+{}
+	
+FScopedMonoUTF8Char::~FScopedMonoUTF8Char()
+{
+	if (Ptr)
+	{
+		FMonoDomain::Free(Ptr);
+	}
+}
+
+FScopedMonoUTF8Char::operator const char*() const 
+{ 
+	return Ptr ? Ptr : ""; 
+}
+
 MonoDomain* FMonoDomain::Domain = nullptr;
 
 MonoGCHandle FMonoDomain::AssemblyLoadContextGCHandle = nullptr;
@@ -505,6 +521,19 @@ MonoString* FMonoDomain::Object_To_String(MonoObject* InMonoObject, MonoObject**
 char* FMonoDomain::String_To_UTF8(MonoString* InMonoString)
 {
 	return InMonoString != nullptr ? mono_string_to_utf8(InMonoString) : nullptr;
+}
+
+FScopedMonoUTF8Char FMonoDomain::String_To_Scoped_UTF8(MonoString* InMonoString)
+{
+	return FScopedMonoUTF8Char(String_To_UTF8(InMonoString));
+}
+	
+void FMonoDomain::Free(void * InPtr)
+{
+	if (InPtr != nullptr)
+	{
+		mono_free(InPtr);
+	}
 }
 
 MonoArray* FMonoDomain::Array_New(MonoClass* InMonoClass, const uint32 InNum)

--- a/Source/UnrealCSharpCore/Private/Dynamic/FDynamicGeneratorCore.cpp
+++ b/Source/UnrealCSharpCore/Private/Dynamic/FDynamicGeneratorCore.cpp
@@ -740,7 +740,7 @@ void FDynamicGeneratorCore::SetFlags(FProperty* InProperty, MonoCustomAttrInfo* 
 			if (const auto FoundProperty = FMonoDomain::Class_Get_Property_From_Name(
 				FMonoDomain::Object_Get_Class(FoundMonoObject), PROPERTY_REP_CALLBACK_NAME))
 			{
-				InProperty->RepNotifyFunc = FName(UTF8_TO_TCHAR(FMonoDomain::String_To_UTF8(
+				InProperty->RepNotifyFunc = FName(UTF8_TO_TCHAR(FMonoDomain::String_To_Scoped_UTF8(
 					(MonoString*)FMonoDomain::Property_Get_Value(FoundProperty, FoundMonoObject, nullptr, nullptr))));
 			}
 		}
@@ -1268,7 +1268,7 @@ FString FDynamicGeneratorCore::AttrGetValue(MonoCustomAttrInfo* InMonoCustomAttr
 
 	const auto Value = FMonoDomain::Property_Get_Value(FoundMonoProperty, FoundMonoObject, nullptr, nullptr);
 
-	return FString(UTF8_TO_TCHAR(FMonoDomain::String_To_UTF8(FMonoDomain::Object_To_String(Value,nullptr))));
+	return FString(UTF8_TO_TCHAR(FMonoDomain::String_To_Scoped_UTF8(FMonoDomain::Object_To_String(Value,nullptr))));
 }
 
 void FDynamicGeneratorCore::GeneratorProperty(MonoClass* InMonoClass, UField* InField,

--- a/Source/UnrealCSharpCore/Public/Domain/FMonoDomain.h
+++ b/Source/UnrealCSharpCore/Public/Domain/FMonoDomain.h
@@ -4,6 +4,19 @@
 #include "FMonoDomainInitializeParams.h"
 #include "mono/metadata/appdomain.h"
 
+class UNREALCSHARPCORE_API FScopedMonoUTF8Char
+{
+public:	
+	~FScopedMonoUTF8Char();	
+	operator const char*() const;
+private:
+	explicit FScopedMonoUTF8Char(char* InPtr);
+	FScopedMonoUTF8Char(const FScopedMonoUTF8Char&) = delete;
+	FScopedMonoUTF8Char& operator=(const FScopedMonoUTF8Char&) = delete;
+	char* Ptr;
+	friend class FMonoDomain;
+};
+
 class UNREALCSHARPCORE_API FMonoDomain
 {
 public:
@@ -133,6 +146,10 @@ public:
 	static MonoString* Object_To_String(MonoObject* InMonoObject, MonoObject** InExc);
 
 	static char* String_To_UTF8(MonoString* InMonoString);
+	
+	static FScopedMonoUTF8Char String_To_Scoped_UTF8(MonoString* InMonoString);
+	
+	static void Free(void * InPtr);
 
 	static MonoArray* Array_New(MonoClass* InMonoClass, uint32 InNum);
 


### PR DESCRIPTION
Fix String_To_UTF8 memory leak issue by replacing with String_To_Scoped_UTF8, String_To_Scoped_UTF8 return a scoped UTF8Char which use RAII to auto release heap memory

Fixes #557