### PR TITLE
Fix String_To_UTF8 memory leak issue by replacing with String_To_Scoped_UTF8

### DIFF
--- a/Source/UnrealCSharp/Private/Domain/FDomain.cpp
+++ b/Source/UnrealCSharp/Private/Domain/FDomain.cpp
@@ -71,6 +71,11 @@ char* FDomain::String_To_UTF8(MonoString* InMonoString)
 	return FMonoDomain::String_To_UTF8(InMonoString);
 }
 
+FScopedMonoUTF8Char FDomain::String_To_Scoped_UTF8(MonoString* InMonoString)
+{
+	return FMonoDomain::String_To_Scoped_UTF8(InMonoString);
+}
+
 MonoObject* FDomain::GCHandle_Get_Target_V2(const MonoGCHandle InGCHandle)
 {
 	return FMonoDomain::GCHandle_Get_Target_V2(InGCHandle);
@@ -92,7 +97,7 @@ FString FDomain::GetTraceback()
 	{
 		if (const auto TracebackMethod = UtilsClass->GetMethod(FUNCTION_UTILS_GET_TRACEBACK, 0))
 		{
-			return FString(UTF8_TO_TCHAR(String_To_UTF8((MonoString*)TracebackMethod->Runtime_Invoke())));
+			return FString(UTF8_TO_TCHAR(String_To_Scoped_UTF8((MonoString*)TracebackMethod->Runtime_Invoke())));
 		}
 	}
 

--- a/Source/UnrealCSharp/Private/Domain/InternalCall/FRegisterAnsiString.cpp
+++ b/Source/UnrealCSharp/Private/Domain/InternalCall/FRegisterAnsiString.cpp
@@ -11,7 +11,7 @@ namespace
 	{
 		static void RegisterImplementation(MonoObject* InMonoObject, MonoString* InValue)
 		{
-			const auto AnsiString = new FAnsiString(UTF8_TO_TCHAR(FDomain::String_To_UTF8(InValue)));
+			const auto AnsiString = new FAnsiString(UTF8_TO_TCHAR(FDomain::String_To_Scoped_UTF8(InValue)));
 
 			FCSharpEnvironment::GetEnvironment().AddStringReference<FAnsiString, true, false>(
 				FReflectionRegistry::Get().GetAnsiStringClass(), InMonoObject, AnsiString);

--- a/Source/UnrealCSharp/Private/Domain/InternalCall/FRegisterName.cpp
+++ b/Source/UnrealCSharp/Private/Domain/InternalCall/FRegisterName.cpp
@@ -9,7 +9,7 @@ namespace
 	{
 		static void RegisterImplementation(MonoObject* InMonoObject, MonoString* InValue)
 		{
-			const auto Name = new FName(UTF8_TO_TCHAR(FDomain::String_To_UTF8(InValue)));
+			const auto Name = new FName(UTF8_TO_TCHAR(FDomain::String_To_Scoped_UTF8(InValue)));
 
 			FCSharpEnvironment::GetEnvironment().AddStringReference<FName, true, false>(
 				FReflectionRegistry::Get().GetNameClass(), InMonoObject, Name);

--- a/Source/UnrealCSharp/Private/Domain/InternalCall/FRegisterObject.cpp
+++ b/Source/UnrealCSharp/Private/Domain/InternalCall/FRegisterObject.cpp
@@ -26,7 +26,7 @@ namespace
 
 		static MonoObject* StaticClassImplementation(MonoString* InClassName)
 		{
-			const auto ClassName = UTF8_TO_TCHAR(FDomain::String_To_UTF8(InClassName));
+			const auto ClassName = UTF8_TO_TCHAR(FDomain::String_To_Scoped_UTF8(InClassName));
 
 			const auto InClass = LoadObject<UClass>(nullptr, ClassName);
 

--- a/Source/UnrealCSharp/Private/Domain/InternalCall/FRegisterString.cpp
+++ b/Source/UnrealCSharp/Private/Domain/InternalCall/FRegisterString.cpp
@@ -9,7 +9,7 @@ namespace
 	{
 		static void RegisterImplementation(MonoObject* InMonoObject, MonoString* InValue)
 		{
-			const auto String = new FString(UTF8_TO_TCHAR(FDomain::String_To_UTF8(InValue)));
+			const auto String = new FString(UTF8_TO_TCHAR(FDomain::String_To_Scoped_UTF8(InValue)));
 
 			FCSharpEnvironment::GetEnvironment().AddStringReference<FString, true, false>(
 				FReflectionRegistry::Get().GetStringClass(), InMonoObject, String);

--- a/Source/UnrealCSharp/Private/Domain/InternalCall/FRegisterStruct.cpp
+++ b/Source/UnrealCSharp/Private/Domain/InternalCall/FRegisterStruct.cpp
@@ -12,7 +12,7 @@ namespace
 	{
 		static MonoObject* StaticStructImplementation(MonoString* InStructName)
 		{
-			const auto StructName = UTF8_TO_TCHAR(FDomain::String_To_UTF8(InStructName));
+			const auto StructName = UTF8_TO_TCHAR(FDomain::String_To_Scoped_UTF8(InStructName));
 
 			const auto InStruct = LoadObject<UScriptStruct>(nullptr, StructName);
 
@@ -21,7 +21,7 @@ namespace
 
 		static void RegisterImplementation(MonoObject* InMonoObject, MonoString* InStructName)
 		{
-			const auto StructName = UTF8_TO_TCHAR(FDomain::String_To_UTF8(InStructName));
+			const auto StructName = UTF8_TO_TCHAR(FDomain::String_To_Scoped_UTF8(InStructName));
 
 			FCSharpEnvironment::GetEnvironment().Bind(InMonoObject, StructName);
 		}

--- a/Source/UnrealCSharp/Private/Domain/InternalCall/FRegisterText.cpp
+++ b/Source/UnrealCSharp/Private/Domain/InternalCall/FRegisterText.cpp
@@ -14,15 +14,15 @@ namespace
 		                                   MonoString* InPackageNamespace, const bool bRequiresQuotes)
 		{
 			const auto Buffer = InBuffer != nullptr
-				                    ? UTF8_TO_TCHAR(FDomain::String_To_UTF8(InBuffer))
+				                    ? UTF8_TO_TCHAR(FDomain::String_To_Scoped_UTF8(InBuffer))
 				                    : nullptr;
 
 			const auto TextNamespace = InTextNamespace != nullptr
-				                           ? UTF8_TO_TCHAR(FDomain::String_To_UTF8(InTextNamespace))
+				                           ? UTF8_TO_TCHAR(FDomain::String_To_Scoped_UTF8(InTextNamespace))
 				                           : nullptr;
 
 			const auto PackageNamespace = InPackageNamespace != nullptr
-				                              ? UTF8_TO_TCHAR(FDomain::String_To_UTF8(InPackageNamespace))
+				                              ? UTF8_TO_TCHAR(FDomain::String_To_Scoped_UTF8(InPackageNamespace))
 				                              : nullptr;
 
 			const auto OutText = new FText();

--- a/Source/UnrealCSharp/Private/Domain/InternalCall/FRegisterUtf8String.cpp
+++ b/Source/UnrealCSharp/Private/Domain/InternalCall/FRegisterUtf8String.cpp
@@ -11,7 +11,7 @@ namespace
 	{
 		static void RegisterImplementation(MonoObject* InMonoObject, MonoString* InValue)
 		{
-			const auto Utf8String = new FUtf8String(UTF8_TO_TCHAR(FDomain::String_To_UTF8(InValue)));
+			const auto Utf8String = new FUtf8String(UTF8_TO_TCHAR(FDomain::String_To_Scoped_UTF8(InValue)));
 
 			FCSharpEnvironment::GetEnvironment().AddStringReference<FUtf8String, true, false>(
 				FReflectionRegistry::Get().GetUtf8StringClass(), InMonoObject, Utf8String);

--- a/Source/UnrealCSharp/Public/Domain/FDomain.h
+++ b/Source/UnrealCSharp/Public/Domain/FDomain.h
@@ -31,6 +31,8 @@ public:
 	static MonoString* String_New(const char* InText);
 
 	static char* String_To_UTF8(MonoString* InMonoString);
+	
+	static FScopedMonoUTF8Char String_To_Scoped_UTF8(MonoString* InMonoString);
 
 	static MonoObject* GCHandle_Get_Target_V2(MonoGCHandle InGCHandle);
 

--- a/Source/UnrealCSharpCore/Private/Domain/FMonoDomain.cpp
+++ b/Source/UnrealCSharpCore/Private/Domain/FMonoDomain.cpp
@@ -27,6 +27,22 @@
 
 PRAGMA_DISABLE_DANGLING_WARNINGS
 
+FScopedMonoUTF8Char::FScopedMonoUTF8Char(char* InPtr) : Ptr(InPtr)
+{}
+	
+FScopedMonoUTF8Char::~FScopedMonoUTF8Char()
+{
+	if (Ptr)
+	{
+		FMonoDomain::Free(Ptr);
+	}
+}
+
+FScopedMonoUTF8Char::operator const char*() const 
+{ 
+	return Ptr ? Ptr : ""; 
+}
+
 MonoDomain* FMonoDomain::Domain = nullptr;
 
 MonoGCHandle FMonoDomain::AssemblyLoadContextGCHandle = nullptr;
@@ -313,6 +329,19 @@ MonoString* FMonoDomain::String_New(const char* InText)
 char* FMonoDomain::String_To_UTF8(MonoString* InMonoString)
 {
 	return InMonoString != nullptr ? mono_string_to_utf8(InMonoString) : nullptr;
+}
+
+FScopedMonoUTF8Char FMonoDomain::String_To_Scoped_UTF8(MonoString* InMonoString)
+{
+	return FScopedMonoUTF8Char(String_To_UTF8(InMonoString));
+}
+	
+void FMonoDomain::Free(void * InPtr)
+{
+	if (InPtr != nullptr)
+	{
+		mono_free(InPtr);
+	}
 }
 
 MonoArray* FMonoDomain::Array_New(MonoClass* InMonoClass, const uint32 InNum)

--- a/Source/UnrealCSharpCore/Private/Reflection/FClassReflection.cpp
+++ b/Source/UnrealCSharpCore/Private/Reflection/FClassReflection.cpp
@@ -197,11 +197,11 @@ void FClassReflection::Initialize()
 		TypeDefinition = this;
 	}
 
-	Name = FString(FMonoDomain::String_To_UTF8(OutName));
+	Name = FString(FMonoDomain::String_To_Scoped_UTF8(OutName));
 
-	NameSpace = FString(FMonoDomain::String_To_UTF8(OutNameSpace));
+	NameSpace = FString(FMonoDomain::String_To_Scoped_UTF8(OutNameSpace));
 
-	PathName = FString(FMonoDomain::String_To_UTF8(OutPathName));
+	PathName = FString(FMonoDomain::String_To_Scoped_UTF8(OutPathName));
 
 	if (Name != CLASS_UTILS && OutParent != nullptr)
 	{
@@ -240,7 +240,7 @@ void FClassReflection::Initialize()
 		for (auto AttributeValueIndex = 0; AttributeValueIndex < AttributeValueCount; ++AttributeValueIndex)
 		{
 			AttributeValues.FindOrAdd(Attribute).Add(FString(
-				FMonoDomain::String_To_UTF8(FMonoDomain::Array_Get<MonoString*>(OutClassAttributeValues,
+				FMonoDomain::String_To_Scoped_UTF8(FMonoDomain::Array_Get<MonoString*>(OutClassAttributeValues,
 					AttributeIndex + AttributeValueIndex))));
 		}
 
@@ -260,7 +260,7 @@ void FClassReflection::Initialize()
 	for (auto PropertyIndex = 0; PropertyIndex < OutPropertyLength; ++PropertyIndex)
 	{
 		auto PropertyName = FString(
-			FMonoDomain::String_To_UTF8(FMonoDomain::Array_Get<MonoString*>(OutPropertyNames, PropertyIndex)));
+			FMonoDomain::String_To_Scoped_UTF8(FMonoDomain::Array_Get<MonoString*>(OutPropertyNames, PropertyIndex)));
 
 		auto AttributeCount = FMonoDomain::Array_Get<int32>(OutPropertyAttributeCounts, PropertyIndex);
 
@@ -281,7 +281,7 @@ void FClassReflection::Initialize()
 
 			for (auto AttributeValueIndex = 0; AttributeValueIndex < AttributeValueCount; ++AttributeValueIndex)
 			{
-				PropertyAttributeValues.FindOrAdd(Attribute).Add(FString(FMonoDomain::String_To_UTF8(
+				PropertyAttributeValues.FindOrAdd(Attribute).Add(FString(FMonoDomain::String_To_Scoped_UTF8(
 					FMonoDomain::Array_Get<MonoString*>(
 						OutPropertyAttributeValues, PropertyAttributeValueIndex + AttributeValueIndex))));
 			}
@@ -303,7 +303,7 @@ void FClassReflection::Initialize()
 	for (auto FieldIndex = 0; FieldIndex < OutFieldLength; ++FieldIndex)
 	{
 		auto FieldName = FString(
-			FMonoDomain::String_To_UTF8(FMonoDomain::Array_Get<MonoString*>(OutFieldNames, FieldIndex)));
+			FMonoDomain::String_To_Scoped_UTF8(FMonoDomain::Array_Get<MonoString*>(OutFieldNames, FieldIndex)));
 
 		Fields.Add(FieldName,
 		           new FFieldReflection(FieldName,
@@ -318,7 +318,7 @@ void FClassReflection::Initialize()
 	for (auto MethodIndex = 0; MethodIndex < OutMethodLength; ++MethodIndex)
 	{
 		auto MethodName = FString(
-			FMonoDomain::String_To_UTF8(FMonoDomain::Array_Get<MonoString*>(OutMethodNames, MethodIndex)));
+			FMonoDomain::String_To_Scoped_UTF8(FMonoDomain::Array_Get<MonoString*>(OutMethodNames, MethodIndex)));
 
 		auto MethodParamCount = FMonoDomain::Array_Get<int32>(OutMethodParamCounts, MethodIndex);
 
@@ -341,7 +341,7 @@ void FClassReflection::Initialize()
 
 			for (auto AttributeValueIndex = 0; AttributeValueIndex < AttributeValueCount; ++AttributeValueIndex)
 			{
-				MethodAttributeValue.FindOrAdd(Attribute).Add(FString(FMonoDomain::String_To_UTF8(
+				MethodAttributeValue.FindOrAdd(Attribute).Add(FString(FMonoDomain::String_To_Scoped_UTF8(
 					FMonoDomain::Array_Get<MonoString*>(
 						OutMethodAttributeValues, MethodAttributeValueIndex + AttributeValueIndex))));
 			}
@@ -372,7 +372,7 @@ void FClassReflection::Initialize()
 
 			for (auto ParamIndex = 0; ParamIndex < MethodParamCount; ++ParamIndex)
 			{
-				auto ParamName = FString(FMonoDomain::String_To_UTF8(
+				auto ParamName = FString(FMonoDomain::String_To_Scoped_UTF8(
 					FMonoDomain::Array_Get<MonoString*>(OutMethodParamNames, MethodParamIndex + ParamIndex)));
 
 				ParamReflections[ParamIndex] = new FParamReflection(

--- a/Source/UnrealCSharpCore/Public/Domain/FMonoDomain.h
+++ b/Source/UnrealCSharpCore/Public/Domain/FMonoDomain.h
@@ -4,6 +4,19 @@
 #include "FMonoDomainInitializeParams.h"
 #include "mono/metadata/appdomain.h"
 
+class UNREALCSHARPCORE_API FScopedMonoUTF8Char
+{
+public:	
+	~FScopedMonoUTF8Char();	
+	operator const char*() const;
+private:
+	explicit FScopedMonoUTF8Char(char* InPtr);
+	FScopedMonoUTF8Char(const FScopedMonoUTF8Char&) = delete;
+	FScopedMonoUTF8Char& operator=(const FScopedMonoUTF8Char&) = delete;
+	char* Ptr;
+	friend class FMonoDomain;
+};
+
 class UNREALCSHARPCORE_API FMonoDomain
 {
 public:
@@ -62,6 +75,10 @@ public:
 	static MonoString* String_New(const char* InText);
 
 	static char* String_To_UTF8(MonoString* InMonoString);
+	
+	static FScopedMonoUTF8Char String_To_Scoped_UTF8(MonoString* InMonoString);
+    	
+    static void Free(void * InPtr);
 
 	static MonoArray* Array_New(MonoClass* InMonoClass, uint32 InNum);
 


### PR DESCRIPTION
String_To_Scoped_UTF8 return a scoped UTF8Char which use RAII to auto release heap memory 

Fix Issue: #557 