### PR TITLE
fix: restore struct reverse lookup and address-based wrapper cleanup

### DIFF
--- a/Source/UnrealCSharp/Private/Reflection/Container/FArrayHelper.cpp
+++ b/Source/UnrealCSharp/Private/Reflection/Container/FArrayHelper.cpp
@@ -340,3 +340,8 @@ FScriptArray* FArrayHelper::GetScriptArray() const
 {
 	return ScriptArray;
 }
+
+void* FArrayHelper::GetAddress() const
+{
+	return ScriptArray;
+}

--- a/Source/UnrealCSharp/Private/Reflection/Container/FMapHelper.cpp
+++ b/Source/UnrealCSharp/Private/Reflection/Container/FMapHelper.cpp
@@ -233,6 +233,11 @@ FScriptMap* FMapHelper::GetScriptMap() const
 	return ScriptMap;
 }
 
+void* FMapHelper::GetAddress() const
+{
+	return ScriptMap;
+}
+
 int32 FMapHelper::GetMaxIndex() const
 {
 	return ScriptMap->GetMaxIndex();

--- a/Source/UnrealCSharp/Private/Reflection/Container/FSetHelper.cpp
+++ b/Source/UnrealCSharp/Private/Reflection/Container/FSetHelper.cpp
@@ -171,6 +171,11 @@ FScriptSet* FSetHelper::GetScriptSet() const
 	return ScriptSet;
 }
 
+void* FSetHelper::GetAddress() const
+{
+	return ScriptSet;
+}
+
 bool FSetHelper::IsValidIndex(const int32 InIndex) const
 {
 	return ScriptSet->IsValidIndex(InIndex);

--- a/Source/UnrealCSharp/Private/Reflection/Delegate/FDelegateHelper.cpp
+++ b/Source/UnrealCSharp/Private/Reflection/Delegate/FDelegateHelper.cpp
@@ -17,6 +17,8 @@ FDelegateHelper::~FDelegateHelper()
 
 void FDelegateHelper::Initialize(FScriptDelegate* InDelegate, UFunction* InSignatureFunction)
 {
+	SetAddress(InDelegate);
+
 	DelegateHandler = NewObject<UDelegateHandler>();
 
 	DelegateHandler->AddToRoot();

--- a/Source/UnrealCSharp/Private/Reflection/Delegate/FMulticastDelegateHelper.cpp
+++ b/Source/UnrealCSharp/Private/Reflection/Delegate/FMulticastDelegateHelper.cpp
@@ -18,6 +18,8 @@ FMulticastDelegateHelper::~FMulticastDelegateHelper()
 
 void FMulticastDelegateHelper::Initialize(FMulticastScriptDelegate* InMulticastDelegate, UFunction* InSignatureFunction)
 {
+	SetAddress(InMulticastDelegate);
+
 	MulticastDelegateHandler = NewObject<UMulticastDelegateHandler>();
 
 	MulticastDelegateHandler->AddToRoot();

--- a/Source/UnrealCSharp/Private/Reflection/Optional/FOptionalHelper.cpp
+++ b/Source/UnrealCSharp/Private/Reflection/Optional/FOptionalHelper.cpp
@@ -100,4 +100,9 @@ void* FOptionalHelper::GetData() const
 {
 	return Data;
 }
+
+void* FOptionalHelper::GetAddress() const
+{
+	return Data;
+}
 #endif

--- a/Source/UnrealCSharp/Private/Registry/FOptionalRegistry.cpp
+++ b/Source/UnrealCSharp/Private/Registry/FOptionalRegistry.cpp
@@ -54,11 +54,13 @@ bool FOptionalRegistry::RemoveReference(const FGarbageCollectionHandle& InGarbag
 {
 	if (const auto FoundValue = OptionalGarbageCollectionHandle2Helper.Find(InGarbageCollectionHandle))
 	{
-		if (const auto FoundGarbageCollectionHandle = OptionalAddress2GarbageCollectionHandle.Find(*FoundValue))
+		const auto Address = (*FoundValue)->GetAddress();
+
+		if (const auto FoundGarbageCollectionHandle = OptionalAddress2GarbageCollectionHandle.Find(Address))
 		{
 			if (*FoundGarbageCollectionHandle == InGarbageCollectionHandle)
 			{
-				OptionalAddress2GarbageCollectionHandle.Remove(*FoundValue);
+				OptionalAddress2GarbageCollectionHandle.Remove(Address);
 			}
 		}
 

--- a/Source/UnrealCSharp/Public/Reflection/Container/FArrayHelper.h
+++ b/Source/UnrealCSharp/Public/Reflection/Container/FArrayHelper.h
@@ -72,6 +72,8 @@ public:
 
 	FScriptArray* GetScriptArray() const;
 
+	void* GetAddress() const;
+
 	FORCEINLINE FScriptArrayHelper CreateHelperFormInnerProperty() const
 	{
 		return FScriptArrayHelper::CreateHelperFormInnerProperty(InnerPropertyDescriptor->GetProperty(), ScriptArray);

--- a/Source/UnrealCSharp/Public/Reflection/Container/FMapHelper.h
+++ b/Source/UnrealCSharp/Public/Reflection/Container/FMapHelper.h
@@ -42,6 +42,8 @@ public:
 
 	FScriptMap* GetScriptMap() const;
 
+	void* GetAddress() const;
+
 	int32 GetMaxIndex() const;
 
 	bool IsValidIndex(int32 InIndex) const;

--- a/Source/UnrealCSharp/Public/Reflection/Container/FSetHelper.h
+++ b/Source/UnrealCSharp/Public/Reflection/Container/FSetHelper.h
@@ -34,6 +34,8 @@ public:
 
 	FScriptSet* GetScriptSet() const;
 
+	void* GetAddress() const;
+
 	bool IsValidIndex(int32 InIndex) const;
 
 	void* GetEnumerator(int32 InIndex) const;

--- a/Source/UnrealCSharp/Public/Reflection/Delegate/FDelegateBaseHelper.h
+++ b/Source/UnrealCSharp/Public/Reflection/Delegate/FDelegateBaseHelper.h
@@ -3,7 +3,24 @@
 class FDelegateBaseHelper
 {
 public:
-	FDelegateBaseHelper() = default;
+	explicit FDelegateBaseHelper(void* InAddress = nullptr):
+		Address(InAddress)
+	{
+	}
 
 	virtual ~FDelegateBaseHelper() = default;
+
+	void* GetAddress() const
+	{
+		return Address;
+	}
+
+protected:
+	void SetAddress(void* InAddress)
+	{
+		Address = InAddress;
+	}
+
+private:
+	void* Address;
 };

--- a/Source/UnrealCSharp/Public/Reflection/Optional/FOptionalHelper.h
+++ b/Source/UnrealCSharp/Public/Reflection/Optional/FOptionalHelper.h
@@ -32,6 +32,8 @@ public:
 
 	void* GetData() const;
 
+	void* GetAddress() const;
+
 private:
 	FOptionalProperty* OptionalProperty;
 

--- a/Source/UnrealCSharp/Public/Registry/FContainerRegistry.inl
+++ b/Source/UnrealCSharp/Public/Registry/FContainerRegistry.inl
@@ -65,12 +65,14 @@ struct FContainerRegistry::TContainerRegistryImplementation<
 	{
 		if (const auto FoundValue = (InRegistry->*GarbageCollectionHandle2Value).Find(InGarbageCollectionHandle))
 		{
+			const auto Address = (*FoundValue)->GetAddress();
+
 			if (const auto FoundGarbageCollectionHandle = (InRegistry->*Address2GarbageCollectionHandle).Find(
-				*FoundValue))
+				Address))
 			{
 				if (*FoundGarbageCollectionHandle == InGarbageCollectionHandle)
 				{
-					(InRegistry->*Address2GarbageCollectionHandle).Remove(*FoundValue);
+					(InRegistry->*Address2GarbageCollectionHandle).Remove(Address);
 				}
 			}
 

--- a/Source/UnrealCSharp/Public/Registry/FDelegateRegistry.inl
+++ b/Source/UnrealCSharp/Public/Registry/FDelegateRegistry.inl
@@ -65,12 +65,14 @@ struct FDelegateRegistry::TDelegateRegistryImplementation<
 	{
 		if (const auto FoundValue = (InRegistry->*GarbageCollectionHandle2Value).Find(InGarbageCollectionHandle))
 		{
+			const auto Address = (*FoundValue)->GetAddress();
+
 			if (const auto FoundGarbageCollectionHandle = (InRegistry->*Address2GarbageCollectionHandle).Find(
-				*FoundValue))
+				Address))
 			{
 				if (*FoundGarbageCollectionHandle == InGarbageCollectionHandle)
 				{
-					(InRegistry->*Address2GarbageCollectionHandle).Remove(*FoundValue);
+					(InRegistry->*Address2GarbageCollectionHandle).Remove(Address);
 				}
 			}
 

--- a/Source/UnrealCSharp/Public/Registry/FStructRegistry.inl
+++ b/Source/UnrealCSharp/Public/Registry/FStructRegistry.inl
@@ -18,6 +18,9 @@ auto FStructRegistry::AddReference(UScriptStruct* InScriptStruct, const void* In
 	const auto GarbageCollectionHandle = FGarbageCollectionHandle::NewWeakRef(
 		FReflectionRegistry::Get().GetClass(InScriptStruct), InMonoObject, true);
 
+	StructAddress2GarbageCollectionHandle.Add(
+		FStructAddressBase(InScriptStruct, const_cast<void*>(InStruct)), GarbageCollectionHandle);
+
 	GarbageCollectionHandle2StructAddress.Add(GarbageCollectionHandle, {
 		                                          InScriptStruct,
 		                                          const_cast<void*>(InStruct),


### PR DESCRIPTION
## 概要

迁移了两类和包装对象生命周期、注册表一致性相关的修复：

1. 在 `FStructRegistry` 中补齐`UStruct` wrapper 的反向查找表注册
2. 修复 container / delegate / optional wrapper 在销毁时按错误 key 删除地址映射的问题，统一改为按真实 native address 清理

## 修复内容

- 修复 C# 直接 `new` 的 `UStruct` 在创建嵌套 struct / container wrapper 时 owner 反查失败的问题
- 修复 wrapper 销毁后 `Address2GarbageCollectionHandle` 残留旧映射的问题

## 本次改动范围

- `FStructRegistry` 的反向查找表注册修复
- container wrapper 的地址清理修复
- delegate wrapper 的地址清理修复
- optional wrapper 的地址清理修复